### PR TITLE
Catch some syntax errors and throw an stack trace

### DIFF
--- a/lib/Method/Signatures/Parser.pm
+++ b/lib/Method/Signatures/Parser.pm
@@ -2,6 +2,7 @@ package Method::Signatures::Parser;
 
 use strict;
 use warnings;
+use Carp ();
 
 use base qw(Exporter);
 our @EXPORT = qw(split_proto);
@@ -14,6 +15,7 @@ sub split_proto {
     require PPI;
     my $ppi = PPI::Document->new(\$proto);
     my $statement = $ppi->find_first("PPI::Statement");
+    Carp::confess("Failed to find statement") unless $statement;
     my $token = $statement->first_token;
 
     my @proto = ('');

--- a/t/lib/Bad.pm
+++ b/t/lib/Bad.pm
@@ -1,0 +1,15 @@
+package Bad;
+
+use strict;
+use warnings;
+use Method::Signatures;
+
+## $info->{} should be $info{}
+method meth2 ($arg) {
+  my %info;
+  $info->{xpto} = 1;
+}
+
+method meth2 ($arg) {}
+
+1;

--- a/t/syntax_errors.t
+++ b/t/syntax_errors.t
@@ -1,0 +1,13 @@
+#!perl
+
+use strict;
+use warnings;
+use lib 't/lib';
+use Test::More;
+use Carp ();
+
+eval { require Bad };
+like($@, qr/^Failed to find statement at/,
+  'Bad syntax generates stack trace');
+
+done_testing();


### PR DESCRIPTION
With some combination that I haven't been able to determine, some syntax errors are not propagated properly as perl syntax errors.

This patch makes those situations at least easier to debug, because the stack trace will include the method where the syntax problems are.
