### PR TITLE
Test::Exception missing as a build_requirement

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -19,6 +19,7 @@ my $build = Module::Build->new(
         'Test::More'        => '0.82',
         'Test::Builder'     => '0.82',
         'Test::Warn'        => '0.10',
+        'Test::Exception'   => '0.31',
     },
 
     requires        => {

--- a/META.json
+++ b/META.json
@@ -18,6 +18,7 @@
          "requires" : {
             "Module::Build" : "0.26",
             "Test::Builder" : "0.82",
+            "Test::Exception" : "0.31",
             "Test::More" : "0.82",
             "Test::Warn" : "0.10"
          }

--- a/META.yml
+++ b/META.yml
@@ -5,6 +5,7 @@ author:
 build_requires:
   Module::Build: 0.26
   Test::Builder: 0.82
+  Test::Exception: 0.31
   Test::More: 0.82
   Test::Warn: 0.10
 configure_requires:


### PR DESCRIPTION
So Test::Exception was in use but wasn't in the build requirements, so I added it. The version I've added is a year old but something lesser would probably suffice.
