### PR TITLE
Change representation of infinity

### DIFF
--- a/lib/Method/Signatures.pm
+++ b/lib/Method/Signatures.pm
@@ -14,6 +14,8 @@ our $DEBUG = $ENV{METHOD_SIGNATURES_DEBUG} || 0;
 
 our @CARP_NOT;
 
+our $INF = ( 0 + "inf" ) == 0 ? 9e9999 : "inf";
+
 sub DEBUG {
     return unless $DEBUG;
 
@@ -908,8 +910,8 @@ sub _calculate_max_args {
 
     # If there's a slurpy argument, the max is infinity.
     if( $overall->{num_slurpy} ) {
-        $overall->{max_argv_size} = 'inf';
-        $overall->{max_args}      = 'inf';
+        $overall->{max_argv_size} = $INF;
+        $overall->{max_args}      = $INF;
 
         return;
     }
@@ -1010,7 +1012,7 @@ sub inject_from_signature {
     my $max_argv = $signature->{overall}{max_argv_size};
     my $max_args = $signature->{overall}{max_args};
     push @code, qq[$class->too_many_args_error($max_args) if \@_ > $max_argv; ]
-        unless $max_argv == "inf";
+        unless $max_argv == $INF;
 
     # All on one line.
     return join ' ', @code;


### PR DESCRIPTION
Under 5.8.9 (unfortunately, I am stuck here for a bit yet), "inf" is not a valid representation of infinity.

Fixes the following errors from testing on master:

``` text
t/method.t                   (Wstat: 1024 Tests: 14 Failed: 4)
  Failed tests:  6-7, 9-10
  Non-zero exit status: 4
t/signature_error_handler.t  (Wstat: 65280 Tests: 2 Failed: 2)
  Failed tests:  1-2
  Non-zero exit status: 255
  Parse errors: No plan found in TAP output
t/too_many_args.t            (Wstat: 1024 Tests: 15 Failed: 4)
  Failed tests:  1-4
  Non-zero exit status: 4
```
