### PR TITLE
Update manifest

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -4,6 +4,7 @@ examples/iso_date_example.t
 examples/strip_ws.t
 lib/Method/Signatures.pm
 lib/Method/Signatures/Modifiers.pm
+lib/Method/Signatures/Parameter.pm
 lib/Method/Signatures/Parser.pm
 MANIFEST			This list of files
 MANIFEST.SKIP


### PR DESCRIPTION
Minor maintenance to MANIFEST file.  Eliminates

``` text
Not in MANIFEST: lib/Method/Signatures/Parameter.pm
MANIFEST appears to be out of sync with the distribution
```

message when doing a Build distclean.
