### PR TITLE
Document that Data::Alias needs be installed to use aliased parameters

### DIFF
--- a/lib/Method/Signatures.pm
+++ b/lib/Method/Signatures.pm
@@ -176,6 +176,7 @@ leads to ambiguities.
 
 =head3 Aliased references
 
+I<Optional, requires L<Data::Alias> to already be installed.>
 A signature of C<\@arg> will take an array reference but allow it to
 be used as C<@arg> inside the method.  C<@arg> is an alias to the
 original reference.  Any changes to C<@arg> will affect the original


### PR DESCRIPTION
Since schwern/method-signatures#77, Data::Alias is no longer installed by default. Adding a note to the Aliased Paramters POD so people may not be so surprised when they see "Can't locate Data::Alias in @INC"

closes schwern/method-signatures#89
