### PR TITLE
Drop Devel::Pragma prereq

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -33,6 +33,7 @@ my $build = Module::Build->new(
         'Any::Moose'        => '0.11',
         Mouse               => '0.64',
         'Sub::Name'         => '0.03',
+        'Lexical::SealRequireHints' => '0.007',
     },
 
     recommends      => {

--- a/lib/Method/Signatures.pm
+++ b/lib/Method/Signatures.pm
@@ -3,6 +3,7 @@ package Method::Signatures;
 use strict;
 use warnings;
 
+use Lexical::SealRequireHints;
 use base 'Devel::Declare::MethodInstaller::Simple';
 use Method::Signatures::Parser;
 use Method::Signatures::Parameter;


### PR DESCRIPTION
Devel::Pragma is only used for a single trivial sub, but loads a
significant amount of code.  It also causes failures on threaded perl.
Remove it as a prereq, and just inline the small bit of code we want
from it.
