### PR TITLE
Set thread-bug.t to be an author-only test for now.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,9 @@
 NEXT
+
+    Test Fixes
+    * Mark thread-bug.t as an author-only test.
+      [github #80, #92]
+
     Distribution Fixes
     * Demand latest version of Devel::Pragma so as to avoid
       load order dependencies

--- a/t/thread-bug.t
+++ b/t/thread-bug.t
@@ -19,6 +19,20 @@ use Test::More;
 
 plan skip_all => 'This test only relevant under threaded Perls' if !$has_threads;
 
+
+BEGIN {
+
+    # Alas, even when this test runs successfully, it still segfaults
+    # on script exit. See GH #92, #80, and elsewhere.
+    #
+    # As such, it's been marked as an author-only test for now.
+
+    plan skip_all => 'Author only test. Set $ENV{AUTHOR_TESTING} to run.'
+        unless $ENV{AUTHOR_TESTING};
+
+}
+
+
 use Method::Signatures;
 
 sub worker {


### PR DESCRIPTION
Right now this is preventing Method::Signatures from installing
on any system with a threaded perl.

See GH #92, #80, and assorted tickets on RT.

(I'm aware that M::S doesn't have any other author-only tests, but this at least gets it installing again on threaded perls.)
