### PR TITLE
Remove 'use experimental', it doesn't work with 5.8.

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -25,7 +25,6 @@ my $build = Module::Build->new(
     requires        => {
         'perl'              => '5.8.1',
 
-        'experimental'      => '0.005',
         'Devel::Declare'    => '0.006002',
         'Devel::Declare::MethodInstaller::Simple' => '0.006002',
         'Const::Fast'       => '0.006',

--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "Michael G Schwern <schwern@pobox.com>"
    ],
    "dynamic_config" : 1,
-   "generated_by" : "Module::Build version 0.4005, CPAN::Meta::Converter version 2.131560",
+   "generated_by" : "Module::Build version 0.4203",
    "license" : [
       "perl_5"
    ],
@@ -42,7 +42,6 @@
             "Mouse" : "0.64",
             "PPI" : "1.203",
             "Sub::Name" : "0.03",
-            "experimental" : "0.005",
             "perl" : "v5.8.1"
          }
       }
@@ -68,9 +67,7 @@
       "bugtracker" : {
          "web" : "http://rt.cpan.org/NoAuth/Bugs.html?Dist=Method-Signatures"
       },
-      "license" : [
-         "http://dev.perl.org/licenses/"
-      ],
+      "license" : "http://dev.perl.org/licenses/",
       "repository" : {
          "url" : "https://github.com/schwern/method-signatures"
       }

--- a/META.yml
+++ b/META.yml
@@ -11,7 +11,7 @@ build_requires:
 configure_requires:
   Module::Build: 0.26
 dynamic_config: 1
-generated_by: 'Module::Build version 0.4005, CPAN::Meta::Converter version 2.131560'
+generated_by: 'Module::Build version 0.4203, CPAN::Meta::Converter version 2.120921'
 license: perl
 meta-spec:
   url: http://module-build.sourceforge.net/META-spec-v1.4.html
@@ -26,8 +26,10 @@ provides:
     version: 20140224
   Method::Signatures::Parameter:
     file: lib/Method/Signatures/Parameter.pm
+    version: 0
   Method::Signatures::Parser:
     file: lib/Method/Signatures/Parser.pm
+    version: 0
 recommends:
   Data::Alias: 1.08
   Moose: 0.96
@@ -40,7 +42,6 @@ requires:
   Mouse: 0.64
   PPI: 1.203
   Sub::Name: 0.03
-  experimental: 0.005
   perl: v5.8.1
 resources:
   bugtracker: http://rt.cpan.org/NoAuth/Bugs.html?Dist=Method-Signatures

--- a/lib/Method/Signatures.pm
+++ b/lib/Method/Signatures.pm
@@ -1151,7 +1151,7 @@ sub inject_for_sig {
                     ? "sub $constraint"
                     : $constraint;
             my $error = sprintf q{ %s->where_error(%s, '%s', '%s') }, $class, $var, $var, $constraint;
-            push @code, "$error unless do { use experimental 'smartmatch'; grep { \$_ ~~ $constraint_impl } $var }; ";
+            push @code, "$error unless do { no if \$] >= 5.017011, warnings => 'experimental::smartmatch'; grep { \$_ ~~ $constraint_impl } $var }; ";
         }
     }
 

--- a/t/where.t
+++ b/t/where.t
@@ -108,7 +108,7 @@ subtest 'where { cat => 1, dog => 2}' => sub {
 
 
 subtest 'where where where' => sub {
-    use experimental 'smartmatch';
+    no if $] >= 5.017011, warnings => 'experimental::smartmatch';
     plan tests => 14;
 
     func is_prime ($x) {


### PR DESCRIPTION
Alas, "use experimental" 0.006 added a requirement for 5.10.
https://metacpan.org/changes/distribution/experimental

Use the equivalent "use if, no warnings" statement instead.

Might be a better long term fix, but this gets Travis working
again on 5.8 and that's more important.
