### PR TITLE
A required positional after an optional positional is an error.

### DIFF
--- a/lib/Method/Signatures/Parameter.pm
+++ b/lib/Method/Signatures/Parameter.pm
@@ -373,11 +373,22 @@ sub check {
             sig_parsing_error("Named parameter '$var' mixed with optional positional '$pos_var'");
         }
     }
-    else {
+    else {  # is_positional
         if( $signature->num_named ) {
             my $named_var = $signature->named_parameters->[-1]->variable;
             my $var = $self->variable;
             sig_parsing_error("Positional parameter '$var' after named param '$named_var'");
+        }
+
+        # Required positional after an optional.
+        # Required positional after a slurpy will be handled elsewhere.
+        if( $self->is_required && $signature->num_optional_positional &&
+            !$signature->num_slurpy
+        ) {
+            my $var = $self->variable;
+            my $opt_pos_var = $signature->optional_positional_parameters->[-1]
+                                        ->variable;
+            sig_parsing_error("Required positional parameter '$var' cannot follow an optional positional parameter '$opt_pos_var'");
         }
     }
 

--- a/t/error_reporting.t
+++ b/t/error_reporting.t
@@ -81,6 +81,14 @@ my %compile_time_errors =
                                                 ],
                                 test_name   =>  'named slurpy param reports correctly',
                             },
+    RequiredAfterOpt =>     {
+                                error_gen   =>  'required_after_optional_error',
+                                error_args  => [
+                                                    '$baz',
+                                                    '$bar',
+                                               ],
+                                test_name   => 'required param after an optional param',
+                            },
 );
 
 my %run_time_errors =

--- a/t/lib/GenErrorRegex.pm
+++ b/t/lib/GenErrorRegex.pm
@@ -6,7 +6,7 @@ use warnings;
 use base qw< Exporter >;
 our @EXPORT_OK =
 (
-    qw< bad_param_error unexpected_after_error named_after_optpos_error pos_after_named_error >,    # compile-time
+    qw< bad_param_error unexpected_after_error named_after_optpos_error pos_after_named_error required_after_optional_error >,    # compile-time
     qw< mispositioned_slurpy_error multiple_slurpy_error named_slurpy_error >,                      # compile-time
     qw< required_error named_param_error badval_error badtype_error >,                              # run-time
 );
@@ -70,6 +70,14 @@ sub named_after_optpos_error
     my ($named, $optpos, %extra) = @_;
 
     return _regexify(COMPILE_TIME => "Named parameter '$named' mixed with optional positional '$optpos'", %extra);
+}
+
+
+sub required_after_optional_error
+{
+    my ($required, $optional, %extra) = @_;
+
+    return _regexify(COMPILE_TIME => "Required positional parameter '$required' cannot follow an optional positional parameter '$optional'", %extra);
 }
 
 

--- a/t/lib/RequiredAfterOpt.pm
+++ b/t/lib/RequiredAfterOpt.pm
@@ -1,0 +1,15 @@
+package RequiredAfterOpt;
+
+use strict;
+use warnings;
+
+use Method::Signatures;
+
+
+# the #line directive helps us guarantee that we'll always know what line number to expect the error
+# on, regardless of how much this test module changes
+#line 1133
+func foo ( $foo, $bar?, $baz ) {}
+
+
+1;


### PR DESCRIPTION
As documented...
- If one positional param is optional, everything to the right must be
  optional
  
     method foo($a, $b?, $c?)  # legal
  
     method bar($a, $b?, $c)   # illegal, ambiguous
  
  Does "->bar(1,2)" mean $a = 1 and $b = 2 or $a = 1, $c = 3?

A required positional after a slurpy technically falls under this, but gets
its own specific error message elsewhere.  This is good because "slurpy
args can only come last" is the information the user needs.

For #108 
