### PR TITLE
Fix B::Lint context warning on generated code

### DIFF
--- a/lib/Method/Signatures.pm
+++ b/lib/Method/Signatures.pm
@@ -876,7 +876,7 @@ sub inject_from_signature {
 
     my $max_argv = $signature->max_argv_size;
     my $max_args = $signature->max_args;
-    push @code, qq[$class->too_many_args_error($max_args) if \@_ > $max_argv; ]
+    push @code, qq[$class->too_many_args_error($max_args) if scalar(\@_) > $max_argv; ]
         unless $max_argv == $INF;
 
     # Add any additional trailing newlines so the body is on the right line.
@@ -948,7 +948,7 @@ sub inject_for_sig {
         $sig->passed_in($rhs);
     }
 
-    my $check_exists = $sig->is_named ? "exists \$args{$name}" : "(\@_ > $idx)";
+    my $check_exists = $sig->is_named ? "exists \$args{$name}" : "( scalar(\@_) > $idx)";
     $sig->check_exists($check_exists);
 
     my $default = $sig->default;


### PR DESCRIPTION
We get implicit scalar context warning on generated code.

This only affects linting of code that ``uses Method::Signatures``. There seem to be a couple of warnings in ``Signatures.pm``, but those don't affect calling code so this patch doesn't address those.