### PR TITLE
Redundantly add use strict & warnings for Kwalitee metrics

### DIFF
--- a/lib/Method/Signatures/Types.pm
+++ b/lib/Method/Signatures/Types.pm
@@ -1,5 +1,8 @@
 package Method::Signatures::Types;
 
+use strict;
+use warnings;
+
 use Mouse::Util::TypeConstraints;
 
 subtype 'Inf',


### PR DESCRIPTION
Test::Kwalitee don't recognuizes that Mouse::Util::TypeConstraits provides
strict and warnings and we fail this  core metric
see http://cpants.cpanauthors.org/dist/Method-Signatures

Signed-off-by: Jose Luis Perez Diez <jluis@escomposlinux.org>