### PR TITLE
Customize Module::Build ACTION_distmeta on Build.PL

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -4,14 +4,36 @@ use 5.008001;
 
 use Module::Build;
 
-my $build = Module::Build->new(
+my $class = Module::Build->subclass(
+    class => 'Module::Build::Custom',
+    code  => <<'SUBCLASS');
+
+sub ACTION_distmeta{
+    my ($self) = @_;
+    if (eval {require Pod::Readme; Pod::Readme->can('new') } ){
+        $self->delete_filetree('README');
+        my $prf = Pod::Readme->new(
+            target      => 'readme',
+            base_dir    => '.',
+            input_file  => $self->_main_docfile,
+            output_file => 'README.pod',
+        );
+        $prf->run();
+	$self->_add_to_manifest('MANIFEST', 'README.pod');
+    }
+    $self->SUPER::ACTION_distmeta;
+};
+   
+SUBCLASS
+
+my $build = $class->new(
     module_name     => 'Method::Signatures',
     license         => 'perl',
 
     recursive_test_files => 1,
 
     configure_requires => {
-        'Module::Build'     => '0.26',
+        'Module::Build'     => '0.31',
     },
 
     build_requires      => {
@@ -50,5 +72,7 @@ my $build = Module::Build->new(
             repository  => 'https://github.com/evalEmpire/method-signatures',
         },
     },
+    create_readme => 1,
+    create_license => 1,
 );
 $build->create_build_script;


### PR DESCRIPTION
generate README.pod for ./Build distmeta and add it to he MANIFEST
so we can have a best documented github repository and a nicer
presentation on github

Update requires as Module::Build needs to be version 0.31 or newer for README generation.
Also we generate a LICENSE file

