### PR TITLE
Bare sigils

### DIFF
--- a/lib/Method/Signatures.pm
+++ b/lib/Method/Signatures.pm
@@ -462,6 +462,22 @@ default values have been resolved, and in the same order as they were
 specified within the signature.
 
 
+=head3 Placeholder parameters
+
+A positional argument can be ignored by using a bare C<$> sigil as its name.
+
+    method foo( $a, $, $c ) {
+        ...
+    }
+
+The argument's value doesn't get stored in a variable, but the caller must
+still supply it.  Value and type constraints can be applied to placeholders.
+
+    method bar( Int $ where { $_ < 10 } ) {
+        ...
+    }
+
+
 =head3 Parameter traits
 
 Each parameter can be assigned a trait with the C<$arg is TRAIT> syntax.
@@ -590,6 +606,10 @@ you can just write:
 
 This is also marginally more efficient, as it does not have to allocate,
 initialize, or deallocate the unused slurpy parameter C<@etc>.
+
+The bare C<@> sigil is a synonym for C<...>.  A bare C<%> sigil is also a
+synonym for C<...>, but requires that there must be an even number of extra
+arguments, such as would be assigned to a hash.
 
 
 =head3 Required and optional parameters

--- a/lib/Method/Signatures.pm
+++ b/lib/Method/Signatures.pm
@@ -938,6 +938,13 @@ sub too_many_args_error {
 }
 
 
+sub odd_number_args_error {
+    my($class) = @_;
+
+    $class->signature_error('was given an odd number of arguments for a placeholder hash');
+}
+
+
 sub named_param_error {
     my ($class, $args) = @_;
     my @keys = keys %$args;
@@ -970,6 +977,12 @@ sub inject_for_sig {
 
     # Add any necessary leading newlines so line numbers are preserved.
     push @code, $self->inject_newlines($sig->first_line_number - $self->{line_number});
+
+    if( $sig->is_hash_yadayada ) {
+        my $is_odd = $sig->position % 2;
+        push @code, qq[$class->odd_number_args_error() if scalar(\@_) % 2 != $is_odd;];
+        return @code;
+    }
 
     my $sigil = $sig->sigil;
     my $name  = $sig->variable_name;

--- a/lib/Method/Signatures/Parameter.pm
+++ b/lib/Method/Signatures/Parameter.pm
@@ -35,6 +35,15 @@ has is_yadayada =>
       return $self->original_code =~ m{^ \s* (?:\Q...\E)|(?:@) \s* $}x;
   };
 
+has is_hash_yadayada =>
+  is            => 'ro',
+  isa           => 'Bool',
+  lazy          => 1,
+  default       => sub {
+      my $self = shift;
+      return $self->original_code =~ m{^ \s* % \s* $}x;
+  };
+
 has type =>
   is            => 'rw',
   isa           => 'Str',

--- a/lib/Method/Signatures/Parameter.pm
+++ b/lib/Method/Signatures/Parameter.pm
@@ -63,13 +63,9 @@ has variable    =>
   default       => '';
 
 has is_placeholder =>
-  is            => 'ro',
+  is            => 'rw',
   isa           => 'Bool',
-  lazy          => 1,
-  default       => sub {
-      my $self = shift;
-      return scalar($self->original_code =~ m{^ (?: \$ | @ | % ) $}x);
-  };
+  default       => 0;
 
 has first_line_number =>
   is            => 'rw',
@@ -349,7 +345,14 @@ sub _preparse_original_code_for_ppi {
     $self->is_named     ($premod =~ m{ :  }x);
     $self->required_flag($postmod) if $postmod;
 
-    $self->variable($self->is_placeholder ? '$tmp' : $var) if $var;
+    if ($var) {
+        if ($var eq '$') {
+            $self->is_placeholder(1);
+            $self->variable('$tmp');
+        } else {
+            $self->variable($var);
+        }
+    }
 
     $self->ppi_clean_code($original_code);
 

--- a/lib/Method/Signatures/Parameter.pm
+++ b/lib/Method/Signatures/Parameter.pm
@@ -5,7 +5,7 @@ use Carp;
 use Method::Signatures::Utils;
 
 my $IDENTIFIER     = qr{ [^\W\d] \w*                         }x;
-my $VARIABLE       = qr{ [\$\@%] $IDENTIFIER                 }x;
+my $VARIABLE       = qr{ [\$\@%] $IDENTIFIER?                }x;
 my $TYPENAME       = qr{ $IDENTIFIER (?: \:\: $IDENTIFIER )* }x;
 our $PARAMETERIZED;
     $PARAMETERIZED = do{ use re 'eval';

--- a/lib/Method/Signatures/Parameter.pm
+++ b/lib/Method/Signatures/Parameter.pm
@@ -62,6 +62,15 @@ has variable    =>
   isa           => 'Str',
   default       => '';
 
+has is_placeholder =>
+  is            => 'ro',
+  isa           => 'Bool',
+  lazy          => 1,
+  default       => sub {
+      my $self = shift;
+      return scalar($self->original_code =~ m{^ (?: \$ | @ | % ) $}x);
+  };
+
 has first_line_number =>
   is            => 'rw',
   isa           => 'Int';
@@ -340,7 +349,7 @@ sub _preparse_original_code_for_ppi {
     $self->is_named     ($premod =~ m{ :  }x);
     $self->required_flag($postmod) if $postmod;
 
-    $self->variable($var)             if $var;
+    $self->variable($self->is_placeholder ? '$tmp' : $var) if $var;
 
     $self->ppi_clean_code($original_code);
 

--- a/lib/Method/Signatures/Parameter.pm
+++ b/lib/Method/Signatures/Parameter.pm
@@ -32,7 +32,7 @@ has is_yadayada =>
   default       => sub {
       my $self = shift;
 
-      return $self->original_code =~ m{^ \s* \Q...\E \s* $}x;
+      return $self->original_code =~ m{^ \s* (?:\Q...\E)|(?:@) \s* $}x;
   };
 
 has type =>

--- a/lib/Method/Signatures/Signature.pm
+++ b/lib/Method/Signatures/Signature.pm
@@ -5,6 +5,7 @@ use Mouse;
 use Method::Signatures::Types;
 use Method::Signatures::Parameter;
 use Method::Signatures::Utils qw(new_ppi_doc sig_parsing_error DEBUG);
+use List::Util qw(all);
 
 my $INF = ( 0 + "inf" ) == 0 ? 9e9999 : "inf";
 
@@ -242,7 +243,9 @@ sub _build_parameters {
     # Split the signature into parameters as tokens.
     my @tokens_by_param = ([]);
     do {
-        if( $token->class eq "PPI::Token::Magic" and $token->content eq '$,' )
+        if( $token->class eq "PPI::Token::Magic"
+            and $token->content eq '$,'
+            and _all_tokens_in_listref_are_whitespace($tokens_by_param[-1]))
         {
             # a placeholder scalar with no constraints gets parsed by PPI  as if it's the special var "$,"
             # it needs to be split up into 2 tokens, "$" and ","
@@ -291,6 +294,12 @@ sub _build_parameters {
     }
 
     return \@params;
+}
+
+
+sub _all_tokens_in_listref_are_whitespace {
+    my $listref = shift;
+    return all { $_->class eq 'PPI::Token::Whitespace' } @$listref;
 }
 
 

--- a/lib/Method/Signatures/Signature.pm
+++ b/lib/Method/Signatures/Signature.pm
@@ -242,6 +242,17 @@ sub _build_parameters {
     # Split the signature into parameters as tokens.
     my @tokens_by_param = ([]);
     do {
+        if( $token->class eq "PPI::Token::Magic" and $token->content eq '$,' )
+        {
+            # a placeholder scalar with no constraints gets parsed by PPI  as if it's the special var "$,"
+            # it needs to be split up into 2 tokens, "$" and ","
+            my $bare_dollar_token = PPI::Token::Cast->new('$');
+            $token->insert_after($bare_dollar_token);
+            $bare_dollar_token->insert_after(PPI::Token::Operator->new(','));
+            $token->remove;
+            $token = $bare_dollar_token;
+        }
+
         if( $token->class eq "PPI::Token::Operator" and $token->content eq ',' )
         {
             push @tokens_by_param, [];

--- a/t/bare_sigils.t
+++ b/t/bare_sigils.t
@@ -1,0 +1,48 @@
+#!/usr/bin/perl -w
+
+# Test the bare sigil syntax: $, @ and %
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use Method::Signatures;
+
+{
+    package Placeholder;
+
+    use lib 't/lib';
+    use GenErrorRegex qw< required_error required_placeholder_error >;
+
+    use Test::More;
+    use Test::Exception;
+    use Method::Signatures;
+
+    method only_placeholder($) {
+        return $self;
+    }
+
+    is( Placeholder->only_placeholder(23),    'Placeholder' );
+
+#line 28
+    throws_ok { Placeholder->only_placeholder() } required_placeholder_error('Placeholder', 0, 'only_placeholder', LINE => 28),
+            'simple required placeholder error okay';
+
+    method add_first_and_last($first!, $, $last = 22) {
+        return $first + $last
+    }
+
+    is( Placeholder->add_first_and_last(18, 19, 20), 18 + 20 );
+    is( Placeholder->add_first_and_last(18, 19),     18 + 22 );
+
+#line 39
+    throws_ok { Placeholder->add_first_and_last() } required_error('Placeholder', '$first', 'add_first_and_last', LINE => 39),
+            'missing required/named param error okay';
+
+#line 43
+    throws_ok { Placeholder->add_first_and_last(18) } required_placeholder_error('Placeholder', 1, 'add_first_and_last', LINE => 43),
+            'missing required placeholder after required param error okay';
+}
+
+done_testing();

--- a/t/bare_sigils.t
+++ b/t/bare_sigils.t
@@ -13,7 +13,7 @@ use Method::Signatures;
     package Placeholder;
 
     use lib 't/lib';
-    use GenErrorRegex qw< required_error required_placeholder_error >;
+    use GenErrorRegex qw< required_error required_placeholder_error placeholder_badval_error placeholder_failed_constraint_error >;
 
     use Test::More;
     use Test::Exception;
@@ -43,6 +43,20 @@ use Method::Signatures;
 #line 43
     throws_ok { Placeholder->add_first_and_last(18) } required_placeholder_error('Placeholder', 1, 'add_first_and_last', LINE => 43),
             'missing required placeholder after required param error okay';
+
+    method constrained_placeholder(Int $ where { $_ < 10 }) {
+        return $self;
+    }
+
+    is( Placeholder->constrained_placeholder(2), 'Placeholder' );
+
+# line 53
+    throws_ok { Placeholder->constrained_placeholder() } required_placeholder_error('Placeholder', 0, 'constrained_placeholder', LINE => 53),
+            'missing requierd constrained placeholder';
+    throws_ok { Placeholder->constrained_placeholder('foo') } placeholder_badval_error('Placeholder', 0, 'Int' => 'foo', 'constrained_placeholder', LINE => 55),
+            'placeholder value wrong type';
+    throws_ok { Placeholder->constrained_placeholder(99) } placeholder_failed_constraint_error('Placeholder', 0, 99 => '{$_<10}', 'constrained_placeholder', LINE => 57),
+            'placeholder value wrong type';
 }
 
 done_testing();

--- a/t/bare_sigils.t
+++ b/t/bare_sigils.t
@@ -64,6 +64,16 @@ use Method::Signatures;
 
     is( Placeholder->slurpy(123), 123, 'slurpy, no extras');
     is( Placeholder->slurpy(123, 456, 789), 123, 'slurpy with extras');
+
+    method slurpy_hash($foo, %) {
+        $foo
+    }
+
+    is( Placeholder->slurpy_hash(123), 123, 'slurpy_hash, no extras');
+    is( Placeholder->slurpy_hash(123, a => 1, b => 2), 123, 'slurpy_hash with extras');
+    throws_ok { Placeholder->slurpy_hash(123, 456, a => 1) }
+        qr{was given an odd number of arguments for a placeholder hash},
+        'slurpy_hash with odd number of extras throws exception';
 }
 
 done_testing();

--- a/t/bare_sigils.t
+++ b/t/bare_sigils.t
@@ -57,6 +57,13 @@ use Method::Signatures;
             'placeholder value wrong type';
     throws_ok { Placeholder->constrained_placeholder(99) } placeholder_failed_constraint_error('Placeholder', 0, 99 => '{$_<10}', 'constrained_placeholder', LINE => 57),
             'placeholder value wrong type';
+
+    method slurpy($foo, @) {
+        $foo
+    }
+
+    is( Placeholder->slurpy(123), 123, 'slurpy, no extras');
+    is( Placeholder->slurpy(123, 456, 789), 123, 'slurpy with extras');
 }
 
 done_testing();

--- a/t/bare_sigils.t
+++ b/t/bare_sigils.t
@@ -74,6 +74,14 @@ use Method::Signatures;
     throws_ok { Placeholder->slurpy_hash(123, 456, a => 1) }
         qr{was given an odd number of arguments for a placeholder hash},
         'slurpy_hash with odd number of extras throws exception';
+
+    method optional_placeholder($foo, $?, $bar?) {
+        return [ $foo, $bar ];
+    }
+
+    is_deeply( Placeholder->optional_placeholder(1), [ 1, undef ], 'optional_placeholder with 1 arg');
+    is_deeply( Placeholder->optional_placeholder(1, 2), [ 1, undef ], 'optional_placeholder with 2 args');
+    is_deeply( Placeholder->optional_placeholder(1, 2, 3), [ 1, 3 ], 'optional_placeholder with 3 args');
 }
 
 done_testing();

--- a/t/bare_sigils.t
+++ b/t/bare_sigils.t
@@ -13,7 +13,7 @@ use Method::Signatures;
     package Placeholder;
 
     use lib 't/lib';
-    use GenErrorRegex qw< required_error required_placeholder_error placeholder_badval_error placeholder_failed_constraint_error >;
+    use GenErrorRegex qw< required_error required_placeholder_error >;
 
     use Test::More;
     use Test::Exception;
@@ -43,20 +43,6 @@ use Method::Signatures;
 #line 43
     throws_ok { Placeholder->add_first_and_last(18) } required_placeholder_error('Placeholder', 1, 'add_first_and_last', LINE => 43),
             'missing required placeholder after required param error okay';
-
-    method constrained_placeholder(Int $ where { $_ < 10 }) {
-        return $self;
-    }
-
-    is( Placeholder->constrained_placeholder(2), 'Placeholder' );
-
-# line 53
-    throws_ok { Placeholder->constrained_placeholder() } required_placeholder_error('Placeholder', 0, 'constrained_placeholder', LINE => 53),
-            'missing requierd constrained placeholder';
-    throws_ok { Placeholder->constrained_placeholder('foo') } placeholder_badval_error('Placeholder', 0, 'Int' => 'foo', 'constrained_placeholder', LINE => 55),
-            'placeholder value wrong type';
-    throws_ok { Placeholder->constrained_placeholder(99) } placeholder_failed_constraint_error('Placeholder', 0, 99 => '{$_<10}', 'constrained_placeholder', LINE => 57),
-            'placeholder value wrong type';
 
     method slurpy($foo, @) {
         $foo

--- a/t/lib/GenErrorRegex.pm
+++ b/t/lib/GenErrorRegex.pm
@@ -8,7 +8,7 @@ our @EXPORT_OK =
 (
     qw< bad_param_error unexpected_after_error named_after_optpos_error pos_after_named_error required_after_optional_error >,    # compile-time
     qw< mispositioned_slurpy_error multiple_slurpy_error named_slurpy_error >,                      # compile-time
-    qw< required_error named_param_error badval_error badtype_error >,                              # run-time
+    qw< required_error required_placeholder_error named_param_error badval_error badtype_error >,   # run-time
 );
 
 
@@ -129,6 +129,14 @@ sub required_error
     my ($obj, $varname, $method, %extra) = @_;
 
     return _regexify($obj, $method, "missing required argument $varname", %extra);
+}
+
+
+sub required_placeholder_error
+{
+    my($obj, $n, $method, %extra) = @_;
+
+    return _regexify($obj, $method, "missing required placeholder argument at position $n", %extra);
 }
 
 

--- a/t/lib/GenErrorRegex.pm
+++ b/t/lib/GenErrorRegex.pm
@@ -8,7 +8,7 @@ our @EXPORT_OK =
 (
     qw< bad_param_error unexpected_after_error named_after_optpos_error pos_after_named_error required_after_optional_error >,    # compile-time
     qw< mispositioned_slurpy_error multiple_slurpy_error named_slurpy_error >,                      # compile-time
-    qw< required_error required_placeholder_error named_param_error badval_error badtype_error >,   # run-time
+    qw< required_error required_placeholder_error named_param_error badval_error placeholder_badval_error badtype_error placeholder_failed_constraint_error >,   # run-time
 );
 
 
@@ -156,11 +156,27 @@ sub badval_error
     return _regexify($obj, $method, "the '$varname' parameter ($val) is not of type $type", %extra);
 }
 
+sub placeholder_badval_error
+{
+    my ($obj, $idx, $type, $val, $method, %extra) = @_;
+
+    $val = defined $val ? qq{"$val"} : 'undef';
+    return _regexify($obj, $method, "the placeholder parameter at position $idx ($val) is not of type $type", %extra);
+}
+
 sub badtype_error
 {
     my ($obj, $type, $submsg, $method, %extra) = @_;
 
     return _regexify($obj, $method, "the type $type is unrecognized ($submsg)", %extra);
+}
+
+sub placeholder_failed_constraint_error
+{
+    my ($obj, $idx, $val, $constraint, $method, %extra) = @_;
+
+    $val = defined $val ? qq{"$val"} : 'undef';
+    return _regexify($obj, $method, "the placeholder parameter at position $idx value ($val) does not satisfy constraint:  $constraint", %extra);
 }
 
 

--- a/t/parameters.t
+++ b/t/parameters.t
@@ -19,8 +19,8 @@ my %tests = (
         '$foo = [1,2,3]', '$bar = { this => 23, that => 42 }'
     ],
     '$code = sub { my $bar = 2+2; }, :$this'    =>  ['$code = sub { my $bar = 2+2; }', ':$this'],
-    '$foo, $, Int $ where { $_ < 10 } = 4, $bar, $'     => [
-        '$foo', '$', 'Int $ where { $_ < 10 } = 4', '$bar', '$'
+    '$foo,    $, Int $ where { $_ < 10 } = 4, $bar, $ = $,, $'     => [
+        '$foo', '$', 'Int $ where { $_ < 10 } = 4', '$bar', '$ = $,', '$'
     ],
     '$foo, @'           => ['$foo', '@'],
     '$foo, %'           => ['$foo', '%'],

--- a/t/parameters.t
+++ b/t/parameters.t
@@ -19,8 +19,8 @@ my %tests = (
         '$foo = [1,2,3]', '$bar = { this => 23, that => 42 }'
     ],
     '$code = sub { my $bar = 2+2; }, :$this'    =>  ['$code = sub { my $bar = 2+2; }', ':$this'],
-    '$foo,    $, Int $ where { $_ < 10 } = 4, $bar, $ = $,, $'     => [
-        '$foo', '$', 'Int $ where { $_ < 10 } = 4', '$bar', '$ = $,', '$'
+    '$foo,    $, $bar, $ = $,, $'     => [
+        '$foo', '$', '$bar', '$ = $,', '$'
     ],
     '$foo, @'           => ['$foo', '@'],
     '$foo, %'           => ['$foo', '%'],
@@ -42,6 +42,19 @@ my %tests = (
 );
 
 while(my($args, $expect) = each %tests) {
+    test_tokenize_sig( $args, $expect );
+}
+
+SKIP: {
+    skip q(Perl 5.10 or later needed to test 'where' constraints), 1 if $] < 5.010;
+    test_tokenize_sig(
+        'Int $ where { $_ < 10 } = 4',
+            [ 'Int $ where { $_ < 10 } = 4' ]
+    );
+};
+
+sub test_tokenize_sig {
+    my($args, $expect) = @_;
     my $sig = Method::Signatures::Signature->new(
         signature_string        => $args,
         # we just want to test the tokenizing

--- a/t/parameters.t
+++ b/t/parameters.t
@@ -19,6 +19,11 @@ my %tests = (
         '$foo = [1,2,3]', '$bar = { this => 23, that => 42 }'
     ],
     '$code = sub { my $bar = 2+2; }, :$this'    =>  ['$code = sub { my $bar = 2+2; }', ':$this'],
+    '$foo, $, Int $ where { $_ < 10 } = 4, $bar, $'     => [
+        '$foo', '$', 'Int $ where { $_ < 10 } = 4', '$bar', '$'
+    ],
+    '$foo, @'           => ['$foo', '@'],
+    '$foo, %'           => ['$foo', '%'],
 
     q[
         $num    = 42,


### PR DESCRIPTION
This branch enables use of bare sigils as placeholders in function signatures, and is meant to resolve #100 and RT/93334
* A bare "$" means accept any scalar value
* A bare "@" is a synonym for "..."
* A bare "%" is also a synonym for "...", but requires an even number of don't-care params