### PR TITLE
Allow function attributes to come before the signature/prototype

### DIFF
--- a/lib/Method/Signatures.pm
+++ b/lib/Method/Signatures.pm
@@ -839,6 +839,49 @@ sub _parser_is_fucked {
 }
 
 
+# Largely copied from Devel::Declare::MethodInstaller::Simple::parser()
+# The original expects things in this order:
+# <keyword> name ($$@) :attr1 :attr2 {
+# * name
+# * prototype
+# * attributes
+# * an open brace
+# We want to support the prototype coming after the attributes as well as before,
+# but D::D::strip_attrs() looks for the open brace, and gets into an endless
+# loop if it doesn't find one.  Meanwhile, D::D::strip_proto() doesn't find anything
+# if the attributes are before the prototype.
+sub parser {
+    my $self = shift;
+    $self->init(@_);
+
+    $self->skip_declarator;
+    my $name   = $self->strip_name;
+
+    my $linestr = Devel::Declare::get_linestr;
+
+    my($proto, $attrs);
+    my($char) = $linestr =~ m/(\(|:)/;
+    if (defined($char) and $char eq '(') {
+        $proto = $self->strip_proto;
+        $attrs = $self->strip_attrs;
+    } else {
+        $attrs = $self->strip_attrs;
+        $proto = $self->strip_proto;
+    }
+
+    my @decl   = $self->parse_proto($proto);
+    my $inject = $self->inject_parsed_proto(@decl);
+    if (defined $name) {
+        $inject = $self->scope_injector_call() . $inject;
+    }
+    $self->inject_if_block($inject, $attrs ? "sub ${attrs} " : '');
+
+    $self->install( $name );
+
+    return;
+}
+
+
 # Capture the function name
 sub strip_name {
     my $self = shift;
@@ -851,10 +894,54 @@ sub strip_name {
 
 
 # Capture the attributes
+# A copy of the method of the same name from Devel::Declare::Context::Simple::strip_attrs()
+# The only change is that the while() loop now terminates if it finds an open brace _or_
+# open paren.  This is necessary to allow the function signature to come after the attributes.
 sub strip_attrs {
     my $self = shift;
 
-    my $attrs = $self->SUPER::strip_attrs(@_);
+    $self->skipspace;
+
+    my $linestr = Devel::Declare::get_linestr;
+    my $attrs   = '';
+
+    if (substr($linestr, $self->offset, 1) eq ':') {
+        while (substr($linestr, $self->offset, 1) ne '{'
+               and substr($linestr, $self->offset, 1) ne '('
+        ) {
+            if (substr($linestr, $self->offset, 1) eq ':') {
+                substr($linestr, $self->offset, 1) = '';
+                Devel::Declare::set_linestr($linestr);
+
+                $attrs .= ':';
+            }
+
+            $self->skipspace;
+            $linestr = Devel::Declare::get_linestr();
+
+            if (my $len = Devel::Declare::toke_scan_word($self->offset, 0)) {
+                my $name = substr($linestr, $self->offset, $len);
+                substr($linestr, $self->offset, $len) = '';
+                Devel::Declare::set_linestr($linestr);
+
+                $attrs .= " ${name}";
+
+                if (substr($linestr, $self->offset, 1) eq '(') {
+                    my $length = Devel::Declare::toke_scan_str($self->offset);
+                    my $arg    = Devel::Declare::get_lex_stuff();
+                    Devel::Declare::clear_lex_stuff();
+                    $linestr = Devel::Declare::get_linestr();
+                    substr($linestr, $self->offset, $length) = '';
+                    Devel::Declare::set_linestr($linestr);
+
+                    $attrs .= "(${arg})";
+                }
+            }
+        }
+
+        $linestr = Devel::Declare::get_linestr();
+    }
+
     $self->{attributes} = $attrs;
 
     return $attrs;

--- a/t/attributes_before_signature.t
+++ b/t/attributes_before_signature.t
@@ -1,0 +1,64 @@
+#!/usr/bin/perl -w
+
+use strict;
+use warnings;
+
+use Test::More 'no_plan';
+
+use attributes;
+
+{
+    package Stuff;
+
+    use Test::More;
+    use Method::Signatures;
+
+    method echo : method ($arg) {
+        return $arg;
+    }
+
+    is( Stuff->echo(42), 42 );
+    is_deeply( [attributes::get \&echo], ['method'] );
+}
+
+
+{
+    package Foo;
+
+    use Test::More;
+    use Method::Signatures;
+
+    my $code = func : method () {};
+    is_deeply( [attributes::get $code], ['method'] );
+}
+
+
+{
+    package Things;
+
+    use attributes;
+    use Method::Signatures;
+
+    my $attrs;
+    my $cb_called;
+
+    sub MODIFY_CODE_ATTRIBUTES {
+        my ($pkg, $code, @attrs) = @_;
+        $cb_called = 1;
+        $attrs = \@attrs;
+        return ();
+    }
+
+    method moo : Bar Baz(fubar) ($foo, $bar) {
+    }
+
+    # Torture test for the attribute handling.
+    method foo
+    :
+    Bar
+    :Moo(:Ko{oh)
+    : Baz(fu{bar:): ($foo, $bar) { return {} }
+
+    ::ok($cb_called, 'attribute handler got called');
+    ::is_deeply($attrs, [qw/Bar Moo(:Ko{oh) Baz(fu{bar:)/], '... with the right attributes');
+}


### PR DESCRIPTION
Attempts to resolve #99 by overriding two method in Devel::Declare that prevented this from working before.  D::D's base parser expects to see a function-like declaration in this order
```
<keyword> name (prototype) : attr1 : attr2 { body }
```

Without these overridden methods, Devel::Declare's strip_attrs() gets stuck in an endless loop looking for the open brace after finding and removing the attributes.  The current offset advances to the open paren starting the signature, and then never advances further.  The overridden strip_attrs() is just a copy of D::D::Context::Simple::strip_attrs() that terminates the loop if it finds ```{``` or ```(```

D::D's strip_proto() will never find the signature if the attribtes are earlier and still in the parse buffer.  So the overridden parser() method looks to see whether ```(``` (a signature/prototype) or ```:``` (attributes) comes earlier, and calls strip_proto() and strip_attrs() in the same order they appear in the source.

I'm not happy with all the copied code from Devel::Declare... Maybe it would be better to patch Devel::Declare with these changes, or at least add hooks in D::D we can use here.