### PR TITLE
 Raise timeout in t/debugger.t (RT#117107)

### DIFF
--- a/t/debugger.t
+++ b/t/debugger.t
@@ -32,7 +32,7 @@ is eval {
     local $SIG{ALRM} = sub { die "Alarm!\n"; };
 
     local $ENV{PERLDB_OPTS} = 'NonStop';
-    alarm 5;
+    alarm 30;
     my $ret = qx{$^X "-Ilib" -dw t/simple.plx};
     alarm 0;
     $ret;


### PR DESCRIPTION
The "debugger" test in t/debugger.t currently sets `alarm 5` which leads to reproducible failures on slow platforms like the Raspberry Pi 1. In practice the test can take over 10 seconds; setting the timeout to `30` should give plenty of wiggle room while still not blocking the whole tests for too long in case of failures.

Fixes: RT#117107